### PR TITLE
workaround for rt#133221

### DIFF
--- a/t/debug.t
+++ b/t/debug.t
@@ -25,7 +25,7 @@ sub baz {
 }
 
 my $ret = bar;
-my $exc = exception { baz $ret, 'ducks'; };
+my $exc = exception { local $Carp::MaxArgNums = 8; baz $ret, 'ducks'; };
 
 like $exc, qr{
     .* \bwith_return\b .* \Q${\__FILE__}\E .* \b 14 \b .* \n


### PR DESCRIPTION
Test::Fatal 0.015, 0.016 set $Carp::MaxArgNums to -1.
This patch sets it to the default value (the value used in 0.014 and earlier) of 8.

see 

 * https://github.com/mauke/Return-MultiLevel/pull/1
 * https://github.com/mauke/Return-MultiLevel/pull/2
 * https://rt.cpan.org/Public/Bug/Display.html?id=133221